### PR TITLE
[native] Enable the use of the cuDF parquet reader

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -118,6 +118,8 @@ if(PRESTO_ENABLE_CUDF)
   set(VELOX_ENABLE_CUDF
       ON
       CACHE BOOL "Enable cuDF support")
+  set(VELOX_ENABLE_PARSE ON)
+  set(VELOX_ENABLE_DUCKDB ON)
   add_compile_definitions(PRESTO_ENABLE_CUDF)
   enable_language(CUDA)
   # Determine CUDA_ARCHITECTURES automatically.

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -94,7 +94,8 @@ target_link_libraries(
   pthread)
 
 if(PRESTO_ENABLE_CUDF)
-  target_link_libraries(presto_server_lib velox_cudf_exec)
+  target_link_libraries(presto_server_lib velox_parse_expression
+                        velox_parse_parser velox_cudf_exec)
 endif()
 
 # Enabling Parquet causes build errors with missing symbols on MacOS. This is

--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -19,5 +19,10 @@ if(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR)
   target_link_libraries(presto_connectors presto_flight_connector)
 endif()
 
+if(PRESTO_ENABLE_CUDF)
+  target_link_libraries(presto_connectors velox_cudf_parquet_connector
+                        cudf::cudf)
+endif()
+
 target_link_libraries(presto_connectors presto_velox_expr_conversion
                       velox_type_fbhive)

--- a/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
@@ -19,6 +19,10 @@
 #include "presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.h"
 #endif
 
+#ifdef PRESTO_ENABLE_CUDF
+#include "velox/experimental/cudf/connectors/parquet/ParquetConnector.h"
+#endif
+
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 
@@ -27,6 +31,7 @@ namespace {
 
 constexpr char const* kHiveHadoop2ConnectorName = "hive-hadoop2";
 constexpr char const* kIcebergConnectorName = "iceberg";
+constexpr char const* kCudfParquetConnectorName = "cudf-parquet";
 
 void registerConnectorFactories() {
   // These checks for connector factories can be removed after we remove the
@@ -58,6 +63,17 @@ void registerConnectorFactories() {
           ArrowFlightConnectorFactory::kArrowFlightConnectorName)) {
     velox::connector::registerConnectorFactory(
         std::make_shared<ArrowFlightConnectorFactory>());
+  }
+#endif
+
+#ifdef PRESTO_ENABLE_CUDF
+  LOG(INFO) << "Registering the cuDF parquet reader factory with name: "
+            << kCudfParquetConnectorName;
+  if (!velox::connector::hasConnectorFactory(kCudfParquetConnectorName)) {
+    velox::connector::registerConnectorFactory(
+        std::make_shared<
+            velox::cudf_velox::connector::parquet::ParquetConnectorFactory>(
+            kCudfParquetConnectorName));
   }
 #endif
 }


### PR DESCRIPTION
Co-authored-by: Luis Garcés-Erice <lga@zurich.ibm.com>

fix compilation when PRESTO_ENABLE_CUDF is OFF
make sure the subfield filter type copy is guarded fix endif for cudf enabled build